### PR TITLE
Change Linux category from Utility+Office to Network

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 			"desktop": {
 				"Terminal": "false",
 				"Type": "Application",
-				"Categories": "GTK;GNOME;Utility;Office;Email;Chat;InstantMessaging;"
+				"Categories": "GTK;GNOME;Network;Email;Chat;InstantMessaging;"
 			},
 			"target": [
 				"AppImage",


### PR DESCRIPTION
I think Rambox fits better in Network than in Utility+Office.