### PR TITLE
Fixes not starting minimized on Linux/MacOS systems

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -165,7 +165,13 @@ function createWindow () {
 	});
 
 	if ( !config.get('start_minimized') && config.get('maximized') ) mainWindow.maximize();
-	if ( config.get('window_display_behavior') !== 'show_trayIcon' && config.get('start_minimized') ) mainWindow.minimize();
+	if ( config.get('window_display_behavior') !== 'show_trayIcon' && config.get('start_minimized') ) {
+		// Wait for the mainWindow.loadURL(..) and the optional mainWindow.webContents.openDevTools() 
+		// to be finished before minimizing
+		mainWindow.webContents.once('did-finish-load', function(e) {
+			mainWindow.minimize();
+		});
+	}
 
 	// Check if the window its outside of the view (ex: multi monitor setup)
 	const { positionOnScreen } = require('./utils/positionOnScreen');


### PR DESCRIPTION
Fixes the bug described in #1205 which states that start-minimized didn't work on (some) Linux/MacOS systems.

Cause:
For some reason calling `BrowserWindow.minimize()` before `BrowserWindow.webContents` didn't finish loading causes the `BrowserWindow` to gain focus an be restored again (on some systems at least). This happens  when the following line
https://github.com/saenzramiro/rambox/blob/3a4c89bd65c23284640d3f098c0b449f96ab6075/electron/main.js#L168
is called before these lines
https://github.com/saenzramiro/rambox/blob/3a4c89bd65c23284640d3f098c0b449f96ab6075/electron/main.js#L181-L185

Fix:
Waiting for the `webContents` `'did-finish-load'` event before minimizing the `BrowserWindow`, which is fired after `BrowserWindow.loadURL(..)` and `BrowserWindow.webContents.openDevTools()` finished.
I also tried just waiting for  the `'ready-to-show'` event of the `BrowserWindow` but that doesn't work when `BrowserWindow.webContents.openDevTools()` is called (so only if `isDev` is set to `false`).

Tested on Windows 10 x64 and Ubuntu 18.04 x64

closes #1205 