### PR TITLE
Fix ICQ's notification javascript.

### DIFF
--- a/app/store/ServicesList.js
+++ b/app/store/ServicesList.js
@@ -362,7 +362,6 @@ Ext.define('Rambox.store.ServicesList', {
 			,url: 'https://web.icq.com/'
 			,type: 'messaging'
 			,js_unread: 'function checkUnread(){let total=0;for(let counter of document.getElementsByClassName("icq-msg-counter"))total+=parseInt("block"===counter.style.display?counter.innerHTML.trim():0);updateBadge(total)}function updateBadge(e){e>=1?rambox.setUnreadCount(e):rambox.clearUnreadCount()}setInterval(checkUnread,3e3);'
-			,dont_update_unread_from_title: true
 			,titleBlink: true
 		},
 		{

--- a/app/store/ServicesList.js
+++ b/app/store/ServicesList.js
@@ -361,7 +361,8 @@ Ext.define('Rambox.store.ServicesList', {
 			,description: locale['services[35]']
 			,url: 'https://web.icq.com/'
 			,type: 'messaging'
-			,js_unread: 'function checkUnread(){updateBadge(parseInt(document.getElementsByClassName("nwa-msg-counter")[0].style.display==="block"?document.getElementsByClassName("nwa-msg-counter")[0].innerHTML.trim():0))}function updateBadge(e){e>=1?document.title="("+e+") "+originalTitle:document.title=originalTitle}var originalTitle=document.title;setInterval(checkUnread,3000);'
+			,js_unread: 'function checkUnread(){let total=0;for(let counter of document.getElementsByClassName("icq-msg-counter"))total+=parseInt("block"===counter.style.display?counter.innerHTML.trim():0);updateBadge(total)}function updateBadge(e){e>=1?rambox.setUnreadCount(e):rambox.clearUnreadCount()}setInterval(checkUnread,3e3);'
+			,dont_update_unread_from_title: true
 			,titleBlink: true
 		},
 		{


### PR DESCRIPTION
ICQ changed the class name it uses, and the existing code only checked the first instance of the class, while ICQ can have many of these, each with their own message count. While we're at it, use the non-title update method recommended in the documentation while we're at it.

It took forever to get a working Windows build environment, but I did test this.

closes #1702 