### PR TITLE
Removed the 'dont_update_from_title' flag

### DIFF
--- a/app/model/Readme.md
+++ b/app/model/Readme.md
@@ -15,13 +15,10 @@ Structure of a service entry:
 |note|Additional info to display when adding the service.|no|
 |manual_notifications|Set to `true` to let Rambox trigger notifications. Can be used for services that doesn't support browser notifications.|no|
 |js_unread|JavaScript code for setting the unread count (see below).|no|
-|dont_update_unread_from_title|Set to `true` to prevent updating the unread count from the window title (see below).|no|
 
 ### Setting the unread count
 
-While there is also a way to set the unread count by adding ` (COUNT)` to the window title, this describes the preferred way of doing it:
-
-First set `dont_update_unread_from_title` in the service config to `true`.
+While by default the unread count is determined by looking for ` (COUNT)` to the window title, this describes the preferred way of doing it:
 
 Code provided by `js_unread` will be injected into the service website.
 You can retrieve the unread count in this JavaScript code e.g. by parsing elements.

--- a/app/model/ServiceList.js
+++ b/app/model/ServiceList.js
@@ -48,9 +48,5 @@ Ext.define('Rambox.model.ServiceList', {
 		 name: 'custom_domain'
 		,type: 'boolean'
 		,defaultValue: false
-	},{
-		 name: 'dont_update_unread_from_title'
-		,type: 'boolean'
-		,defaultValue: false
 	}]
 });

--- a/app/store/ServicesList.js
+++ b/app/store/ServicesList.js
@@ -29,7 +29,6 @@ Ext.define('Rambox.store.ServicesList', {
 			,url: 'https://web.whatsapp.com/'
 			,type: 'messaging'
 			,js_unread: 'function checkUnread(){const elements = document.querySelectorAll(\'.CxUIE, .unread\');let count = 0;for (let i = 0; i < elements.length; i++) {if (elements[i].querySelectorAll(\'*[data-icon="muted"]\').length === 0) {count++;}}updateBadge(count);}function updateBadge(count){if(count && count>=1){rambox.setUnreadCount(count);}else{rambox.clearUnreadCount();}}setInterval(checkUnread, 1e3);'
-			,dont_update_unread_from_title: true
 		},
 		{
 			 id: 'slack'
@@ -77,7 +76,6 @@ Ext.define('Rambox.store.ServicesList', {
 			,type: 'messaging'
 			,titleBlink: true
 			,manual_notifications: true
-			,dont_update_unread_from_title: true
 			,js_unread: 'function checkUnread(){updateBadge(document.getElementById("hangout-landing-chat").lastChild.contentWindow.document.body.getElementsByClassName("ee").length)}function updateBadge(e){e>=1?rambox.setUnreadCount(e):rambox.clearUnreadCount()}setInterval(checkUnread,3000);'
 		},
 		{
@@ -98,7 +96,6 @@ Ext.define('Rambox.store.ServicesList', {
 			,url: 'https://web.telegram.org/'
 			,type: 'messaging'
 			,js_unread: 'function checkUnread(){var e=document.getElementsByClassName("im_dialog_badge badge"),t=0;for(i=0;i<e.length;i++)if(!e[i].classList.contains("im_dialog_badge_muted")){t+=parseInt(e[i].innerHTML.trim())}updateBadge(t)}function updateBadge(e){e>=1?rambox.setUnreadCount(e):rambox.clearUnreadCount()}setInterval(checkUnread,3000);'
-			,dont_update_unread_from_title: true
 		},
 		{
 			 id: 'wechat'
@@ -118,7 +115,6 @@ Ext.define('Rambox.store.ServicesList', {
 			,allow_popups: true
 			,js_unread: 'function checkUnread(){var a=document.getElementsByClassName("aim")[0];updateBadge(-1!=a.textContent.indexOf("(")&&(t=parseInt(a.textContent.replace(/[^0-9]/g,""))))}function updateBadge(a){a>=1?rambox.setUnreadCount(a):rambox.clearUnreadCount()}setInterval(checkUnread,3e3);'
 			,note: 'To enable desktop notifications, you have to go to Settings inside Gmail. <a href="https://support.google.com/mail/answer/1075549?ref_topic=3394466" target="_blank">Read more...</a>'
-			,dont_update_unread_from_title: true
 		},
 		{
 			 id: 'inbox'
@@ -149,7 +145,6 @@ Ext.define('Rambox.store.ServicesList', {
 			,type: 'messaging'
 			,note: 'To enable desktop notifications, you have to go to Options inside GroupMe. To count unread messages, be sure to be in Chats.'
 			,js_unread: 'function checkUnread(){var a=document.querySelectorAll(".badge-count:not(.ng-hide)"),b=0;for(i=0;i<a.length;i++)b+=parseInt(a[i].innerHTML.trim());updateBadge(b)}function updateBadge(a){a>=1?rambox.setUnreadCount(a):rambox.clearUnreadCount()}setInterval(checkUnread,3e3);'
-			,dont_update_unread_from_title: true
 		},
 		{
 			 id: 'grape'
@@ -514,7 +509,6 @@ Ext.define('Rambox.store.ServicesList', {
 			,url: 'https://www.icloud.com/#mail'
 			,type: 'email'
 			,js_unread: 'function checkUnread(){updateBadge(document.querySelector(".current-app").querySelector(".sb-badge").style.display==="none"?0:parseInt(document.querySelector(".current-app").querySelector(".text").innerHTML.trim()))}function updateBadge(a){a>=1?rambox.setUnreadCount(a):rambox.clearUnreadCount()}setInterval(checkUnread,3e3);'
-			,dont_update_unread_from_title: true
 		},
 		{
 			 id: 'rainloop'
@@ -644,7 +638,6 @@ Ext.define('Rambox.store.ServicesList', {
 			,url: 'https://web.flock.co/'
 			,type: 'messaging'
 			,js_unread: 'function checkUnread(){var a=document.getElementsByClassName("unreadMessages no-unread-mentions has-unread"),b=0;for(i=0;i<a.length;i++)b+=parseInt(a[i].innerHTML.trim());updateBadge(b)}function updateBadge(a){a>=1?rambox.setUnreadCount(a):rambox.clearUnreadCount()}setInterval(checkUnread,3e3);'
-			,dont_update_unread_from_title: true
 
 		},
 		{
@@ -671,7 +664,6 @@ Ext.define('Rambox.store.ServicesList', {
 			url: 'https://www.xing.com/messages/conversations',
 			type: 'messaging',
 			js_unread: '(function() { let originalTitle = document.title; function checkUnread() { let count = null; let notificationElement = document.querySelector(\'[data-update="unread_conversations"]\'); if (notificationElement && notificationElement.style.display !== \'none\') { count = parseInt(notificationElement.textContent.trim(), 10); } updateBadge(count); } function updateBadge(count) { if (count && count >= 1) { rambox.setUnreadCount(count); } else { rambox.clearUnreadCount(); } } setInterval(checkUnread, 3000); checkUnread(); })();',
-			dont_update_unread_from_title: true
 		},
 		{
 			id: 'threema',
@@ -681,7 +673,6 @@ Ext.define('Rambox.store.ServicesList', {
 			url: 'https://web.threema.ch/',
 			type: 'messaging',
 			js_unread: '(function () { let unreadCount = 0; function checkUnread() { let newUnread = 0; try { let webClientService = angular.element(document.documentElement).injector().get(\'WebClientService\'); let conversations = webClientService.conversations.conversations; conversations.forEach(function(conversation) { newUnread += conversation.unreadCount; }); } catch (e) { } if (newUnread !== unreadCount) { unreadCount = newUnread; updateBadge(unreadCount); } } function updateBadge(count) { if (count && count >= 1) { rambox.setUnreadCount(count); } else { rambox.clearUnreadCount(); } } setInterval(checkUnread, 3000); checkUnread(); })();',
-			dont_update_unread_from_title: true
 		},
 		{
 			 id: 'workplace'
@@ -733,7 +724,6 @@ Ext.define('Rambox.store.ServicesList', {
 			,url: 'https://app.zyptonite.com/'
 			,type: 'messaging'
 			,js_unread: 'function checkUnread(){var a=document.getElementsByClassName("z-messages"),b=0;for(i=0;i<a.length;i++)b+=parseInt(a[i].innerHTML.trim());updateBadge(b)}function updateBadge(a){a>=1?rambox.setUnreadCount(a):rambox.clearUnreadCount()}setInterval(checkUnread,3e3);'
-			,dont_update_unread_from_title: true
 		},
 		{
 			 id: 'fastmail'
@@ -806,7 +796,6 @@ Ext.define('Rambox.store.ServicesList', {
 			,url: 'https://___/chat'
 			,type: 'messaging'
 			,js_unread: 'function checkUnread(){updateBadge(parseInt(document.getElementsByClassName("sidebar-notification-indicator").length > 0 ? document.getElementsByClassName("sidebar-notification-indicator")[0].innerHTML : 0))}function updateBadge(a){a>=1?rambox.setUnreadCount(a):rambox.clearUnreadCount()}setInterval(checkUnread,3e3);'
-			,dont_update_unread_from_title: true
 		},
 		{
 			 id: 'clocktweets'
@@ -824,7 +813,6 @@ Ext.define('Rambox.store.ServicesList', {
 			,url: 'https://app.intercom.io'
 			,type: 'messaging'
 			,js_unread: 'function checkUnread(){var a=document.getElementsByClassName("unread")[0];updateBadge(t=a===undefined?0:parseInt(a.textContent.replace(/[^0-9]/g,"")))}function updateBadge(a){a>=1?rambox.setUnreadCount(a):rambox.clearUnreadCount()}setInterval(checkUnread,3000);'
-			,dont_update_unread_from_title: true
 		},
 		{
 			 id: 'allo'
@@ -834,7 +822,6 @@ Ext.define('Rambox.store.ServicesList', {
 			,url: 'https://allo.google.com/web'
 			,type: 'messaging'
 			,js_unread: 'function checkUnread(){var e=document.querySelectorAll(".hasUnread.conversation_item"),n=0;for(i=0;i<e.length;i++){var m=e[i].querySelector("#muted"),u=e[i].querySelector(".unreadCount"),c=parseInt(u.innerHTML.trim()),r=(m===null||m.style.display==="none")?c:0;n+=isNaN(r)?0:r}updateBadge(n)}function updateBadge(e){e&&e>=1?rambox.setUnreadCount(e):rambox.clearUnreadCount()}setInterval(checkUnread,3e3);'
-			,dont_update_unread_from_title: true
 		},
 		{
 			 id: 'Kune'
@@ -906,7 +893,6 @@ Ext.define('Rambox.store.ServicesList', {
 			,type: 'messaging'
 			,titleBlink: true
 			,manual_notifications: true
-			,dont_update_unread_from_title: true
 			,js_unread: 'function checkUnread(){updateBadge(document.querySelectorAll(".SSPGKf.EyyDtb.Q6oXP:not(.oCHqfe) .eM5l9e.FVKzAb").length)}function updateBadge(e){e>=1?rambox.setUnreadCount(e):rambox.clearUnreadCount()}setInterval(checkUnread,3000);'
 		}
 	]

--- a/app/store/ServicesList.js
+++ b/app/store/ServicesList.js
@@ -37,7 +37,7 @@ Ext.define('Rambox.store.ServicesList', {
 			,description: locale['services[1]']
 			,url: 'https://___.slack.com/'
 			,type: 'messaging'
-			,js_unread: 'function checkUnread(){var e=$(".p-channel_sidebar__channel--unread:not(.p-channel_sidebar__channel--muted)").length,a=0;$(".p-channel_sidebar__badge").each(function(){a+=isNaN(parseInt($(this).html()))?0:parseInt($(this).html())}),updateBadge(e,a)}function updateBadge(e,a){var n=a>0?"("+a+") ":e>0?"(•) ":"";document.title=n+originalTitle}var originalTitle=document.title;setInterval(checkUnread,3e3);'
+			,js_unread: 'function checkUnread(){var e=$(".p-channel_sidebar__channel--unread:not(.p-channel_sidebar__channel--muted)").length,n=0;$(".p-channel_sidebar__badge").each(function(){n+=isNaN(parseInt($(this).html()))?0:parseInt($(this).html())}),count=0<n?n:0<e?"•":0,updateBadge(count)}function updateBadge(e){1<=e||"•"===e?rambox.setUnreadCount(e):rambox.clearUnreadCount();}setInterval(checkUnread,3e3);'
 		},
 		{
 			 id: 'noysi'

--- a/app/ux/WebView.js
+++ b/app/ux/WebView.js
@@ -477,14 +477,15 @@ Ext.define('Rambox.ux.WebView',{
 
 			/**
 			 * Handles 'rambox.setUnreadCount' messages.
-			 * Sets the badge text if the event contains an integer as first argument.
+			 * Sets the badge text if the event contains an integer
+                         * or a '•' (indicating non-zero but unknown number of unreads) as first argument.
 			 *
 			 * @param event
 			 */
 			function handleSetUnreadCount(event) {
 				if (Array.isArray(event.args) === true && event.args.length > 0) {
 					var count = event.args[0];
-					if (count === parseInt(count, 10)) {
+					if (count === parseInt(count, 10) || "•" === count) {
 						me.setUnreadCount(count);
 					}
 				}

--- a/app/ux/WebView.js
+++ b/app/ux/WebView.js
@@ -497,9 +497,10 @@ Ext.define('Rambox.ux.WebView',{
 		});
 
 		/**
-		 * Register page title update event listener only for services that don't prevent it by setting 'dont_update_unread_from_title' to true.
+		 * Register page title update event listener only for services that don't specify a js_unread
 		 */
-		if (Ext.getStore('ServicesList').getById(me.record.get('type')).get('dont_update_unread_from_title') !== true) {
+		if (Ext.getStore('ServicesList').getById(me.record.get('type')).get('js_unread') === '' && 
+                        me.record.get('js_unread') === '') {
 			webview.addEventListener("page-title-updated", function(e) {
 				var count = e.title.match(/\(([^)]+)\)/); // Get text between (...)
 				count = count ? count[1] : '0';


### PR DESCRIPTION
As proposed in #1728 I removed the dont_update_from_title flag.
Unread count is now parsed from title if and only if no js_unread is configured.

Note that all services that set the flag, also have a js_unread, so nothing changes for those.
In the unlikely case you want both js_unread and update from title, you could add the update from title code to js_unread. If you want neither, you can have a nonempty no-op js_unread.

The big improvement is that it's now possible to have a Custom Service that does not update from title,  as mentioned in the comments of #1250 .

Closes #1716 
Closes #1728

(oh and if someone could review the one line of javascript I changed in app/ux/WebView.js)