### PR TITLE
[mod] Tutanota URL

### DIFF
--- a/app/store/ServicesList.js
+++ b/app/store/ServicesList.js
@@ -242,7 +242,7 @@ Ext.define('Rambox.store.ServicesList', {
 			,logo: 'tutanota.png'
 			,name: 'Tutanota'
 			,description: locale['services[21]']
-			,url: 'https://app.tutanota.de/'
+			,url: 'https://mail.tutanota.com/'
 			,type: 'email'
 		},
 		{


### PR DESCRIPTION
As Tutanota has a new client now, I think the best is to change URL here.

Client already released on smartphone/Iphone app : https://tutanota.com/blog/posts/release-notes-3-35