### PR TITLE
Fixed issue with gmail and notifications

### DIFF
--- a/resources/js/rambox-service-api.js
+++ b/resources/js/rambox-service-api.js
@@ -38,7 +38,7 @@ Notification = function(title, options) {
 		ipcRenderer.sendToHost('rambox.showWindowAndActivateTab');
 	});
 	
-	//It seems that gmail is checking if such event handler func are available. Just remplacing them by a void function that is always returning true is making the rights rights!
+	//It seems that gmail is checking if such event handler func are available. Just remplacing them by a void function that is always returning true is making the thing right!
 	notification.addEventListener = function(a, b) {return true};
 	notification.attachEvent = function(a, b) {return true};
 	notification.addListener = function(a, b) {return true};

--- a/resources/js/rambox-service-api.js
+++ b/resources/js/rambox-service-api.js
@@ -37,6 +37,11 @@ Notification = function(title, options) {
 	notification.addEventListener('click', function() {
 		ipcRenderer.sendToHost('rambox.showWindowAndActivateTab');
 	});
+	
+	//It seems that gmail is checking if such event handler func are available. Just remplacing them by a void function that is always returning true is making the rights rights!
+	notification.addEventListener = function(a, b) {return true};
+	notification.attachEvent = function(a, b) {return true};
+	notification.addListener = function(a, b) {return true};
 
 	return notification;
 }


### PR DESCRIPTION
A lot of issues was reporting that clicking on a notification from gmail was opening an external tab.
Simply disabling addEventListener is working.

- Closes #834
- Closes #1098