### PR TITLE
Fixed incorrect unread display in Mattermost

### DIFF
--- a/app/store/ServicesList.js
+++ b/app/store/ServicesList.js
@@ -330,7 +330,7 @@ Ext.define('Rambox.store.ServicesList', {
 			,description: locale['services[32]']
 			,url: '___'
 			,type: 'messaging'
-			,js_unread: 'function checkUnread(){var a=document.title.match(/\(([^()]+)\)/);a=isNaN(parseInt(a))?"*"===document.title[0]?"\u2022":"0":parseInt(a[1]),updateBadge(a)}function updateBadge(a){1<=a||"\u2022"===a?rambox.setUnreadCount(a):rambox.clearUnreadCount()}setInterval(checkUnread,3e3);'
+			,js_unread: 'function checkUnread(){updateBadge(document.title[0]==="("?Number(document.title.match(/\(([^()]+)\)/)[1]):document.title[0]==="*"?"\u2022":"0")}function updateBadge(a){a>0||a==="\u2022"?rambox.setUnreadCount(a):rambox.clearUnreadCount()}setInterval(checkUnread,3e3);'
 		},
 		{
 			 id: 'dingtalk'


### PR DESCRIPTION
When you open a channel starting with a number in Mattermost, the notification count showed that number as the amount of unread messages, this should fix that.