### PR TITLE
Fix unread js for discord dm count

### DIFF
--- a/app/store/ServicesList.js
+++ b/app/store/ServicesList.js
@@ -182,7 +182,7 @@ Ext.define('Rambox.store.ServicesList', {
 			,url: 'https://discordapp.com/login'
 			,type: 'messaging'
 			,titleBlink: true
-			,js_unread: 'function getAlertCount(e){for(var t=0,a=0;a<e.length;a++){var r=e[a];if(r&&r.childNodes&&0<r.childNodes.length){var d=parseInt(r.childNodes[0].nodeValue,10);t+=d.isNaN?1:d}else t++}return t}function checkUnread(){var e=0;dms=document.querySelectorAll("[class*=dms]")[0].querySelectorAll("[class*=wrapper][class*=badge]"),updateBadge(0,e+=getAlertCount(dms))}function updateBadge(e,t){rambox.setUnreadCount(t)}setInterval(checkUnread,3e3);'
+			,js_unread: 'function checkUnread(){var e=document.querySelectorAll("[class*=scroller] [class*=container]"),r=Array.from(e.values()).reduce((e,r)=>e+(r&&r.querySelector("[class*=avatar]")&&r.querySelector("[class*=wrapper][class*=badge]")?parseInt(r.querySelector("[class*=wrapper][class*=badge]").innerHTML):0),0);rambox.setUnreadCount(r)}setInterval(checkUnread,3e3);'
 			,note: 'To enable desktop notifications, you have to go to Options inside Discord. Will count only unread DMs.'
 			,userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36'
 		},


### PR DESCRIPTION
A replacement for the new discord html organisation.
It's now counting dms back again.
code (put it in advanced):

__To count only DMs & group discussions__
```js
function checkUnread(){var e=document.querySelectorAll("[class*=scroller] [class*=container]"),r=Array.from(e.values()).reduce((e,r)=>e+(r&&r.querySelector("[class*=avatar]")&&r.querySelector("[class*=wrapper][class*=badge]")?parseInt(r.querySelector("[class*=wrapper][class*=badge]").innerHTML):0),0);rambox.setUnreadCount(r)}setInterval(checkUnread,3e3);
```

__To count every mention (from every servers, dms...)__
```js
function checkUnread(){var e=document.querySelectorAll("[class*=scroller] [class*=container]"),r=Array.from(e.values()).reduce((e,r)=>e+(r&&r.querySelector("[class*=wrapper][class*=badge]")?parseInt(r.querySelector("[class*=wrapper][class*=badge]").innerHTML):0),0);rambox.setUnreadCount(r)}setInterval(checkUnread,3e3);
```

fixes: #2123  