### PR TITLE
Fix electron webview keyinput event not propagaded

### DIFF
--- a/app/Application.js
+++ b/app/Application.js
@@ -24,7 +24,6 @@ Ext.define('Rambox.Application', {
 		 totalServicesLoaded: 0
 		,totalNotifications: 0
 	}
-	,xtype : 'application-controller'
 	,launch: function () {
 		// Prevent track if the user have disabled this option (default: false)
 		if ( !ipc.sendSync('sendStatistics') ) {

--- a/app/Application.js
+++ b/app/Application.js
@@ -24,7 +24,7 @@ Ext.define('Rambox.Application', {
 		 totalServicesLoaded: 0
 		,totalNotifications: 0
 	}
-
+	,xtype : 'application-controller'
 	,launch: function () {
 		// Prevent track if the user have disabled this option (default: false)
 		if ( !ipc.sendSync('sendStatistics') ) {
@@ -60,7 +60,7 @@ Ext.define('Rambox.Application', {
 		if ( require('electron').remote.process.argv.indexOf('--without-update') === -1 ) Rambox.app.checkUpdate(true);
 
 		// Add shortcuts to switch services using CTRL + Number
-		var map = new Ext.util.KeyMap({
+		document.keyMapping = new Ext.util.KeyMap({
 			 target: document
 			,binding: [
 				{

--- a/app/ux/WebView.js
+++ b/app/ux/WebView.js
@@ -459,7 +459,7 @@ Ext.define('Rambox.ux.WebView',{
 				return;
 			}
 			// because keyCode property is not passed
-			const keycode = require('keycode')
+			const keycode = require('keycodes')
 			// Create a fake KeyboardEvent from the data provided
 			var emulatedKeyboardEvent = new KeyboardEvent('keydown', {
 				code: input.code,

--- a/app/ux/WebView.js
+++ b/app/ux/WebView.js
@@ -454,6 +454,29 @@ Ext.define('Rambox.ux.WebView',{
 
 			webview.executeJavaScript(js_inject);
 		});
+		webview.getWebContents().on('before-input-event', (event, input) => {
+			if (input.type !== 'keyDown') { // event used by default
+				return;
+			}
+			// because keyCode property is not passed
+			const keycode = require('keycode')
+			// Create a fake KeyboardEvent from the data provided
+			var emulatedKeyboardEvent = new KeyboardEvent('keydown', {
+				code: input.code,
+				key: input.key,
+				shiftKey: input.shift,
+				altKey: input.alt,
+				ctrlKey: input.control,
+				metaKey: input.meta,
+				repeat: input.isAutoRepeat,
+				keyCode: keycode(input.key) //get real key code
+			});
+			emulatedKeyboardEvent.getKey = function() {
+				return this.keyCode || this.charCode // fake function, normally used by Ext.js, simply returning keyCode
+			}
+			document.keyMapping.handleTargetEvent(emulatedKeyboardEvent) // we directly trigger  handleTargetEvent. That's a private method normally. We can't fire the event directly with document.dispatch, unfortunately
+
+		});
 
 		webview.addEventListener('ipc-message', function(event) {
 			var channel = event.channel;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3105,10 +3105,10 @@
 				"verror": "1.10.0"
 			}
 		},
-		"keycode": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
-			"integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
+		"keycodes": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/keycodes/-/keycodes-1.0.0.tgz",
+			"integrity": "sha512-ukEttiO9Sjb/dj29GQw3/mVXyI3575QTtvetCJfBrVjytESKefRHCt7GUmruvFwWIUqvMD9p5uk7Y3y//4B+hw=="
 		},
 		"klaw": {
 			"version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "Rambox",
-	"version": "0.6.3",
+	"version": "0.6.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1862,7 +1862,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				},
@@ -3104,6 +3104,11 @@
 				"json-schema": "0.2.3",
 				"verror": "1.10.0"
 			}
+		},
+		"keycode": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
+			"integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
 		},
 		"klaw": {
 			"version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
 		"electron-log": "^2.2.17",
 		"electron-store": "^2.0.0",
 		"electron-updater": "^3.1.2",
-		"keycode": "^2.2.0",
+		"keycodes": "^1.0.0",
 		"mime": "^2.3.1",
 		"request": "^2.88.0",
 		"request-promise": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -189,6 +189,7 @@
 		"electron-log": "^2.2.17",
 		"electron-store": "^2.0.0",
 		"electron-updater": "^3.1.2",
+		"keycode": "^2.2.0",
 		"mime": "^2.3.1",
 		"request": "^2.88.0",
 		"request-promise": "^4.2.2",


### PR DESCRIPTION
Since chromium's architecture has been reworked, events are not propaged globally anymore. Rambox was using this hack to handle CTRL+TAB, but with the new electron version, it's not working anymore.
A workaround is to handle the events fired by webview.

Here is a fix.

Fixes #2125 
Fixes #2127
Fixes #2136
Fixes #2161 
Fixes #2159 
Fixes #2164 
