### PR TITLE
Update sencha required version to 6.6.0.13 in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Working on your first Pull Request? You can learn how from this *free* series [H
 
 | Prerequisite                                                  | Version |
 | ------------------------------------------------------------- | ------- |
-| [Sencha](https://www.sencha.com/products/extjs/cmd-download/) | `=6.1.2.15`  |
+| [Sencha](https://www.sencha.com/products/extjs/cmd-download/) | `=6.6.0.13`  |
 | [Ruby](https://www.ruby-lang.org/en/downloads/)               | `=2.3` |
 | [Node.js](https://nodejs.org)                                 | `~ ^4.0.0`  |
 | npm (comes with Node)                                         | `~ ^3.8.7`  |


### PR DESCRIPTION
Otherwise you get the error message:
```
This application was last changed by a sencha version of 6.6.0.13. Please update your sencha version to 6.6.0.13.
```
When you run command:
```
sencha app watch
```