### PR TITLE
Allow mainWindow to be undefined

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -454,7 +454,9 @@ app.on('activate', function () {
 		config.get('master_password') ? createMasterPasswordWindow() : createWindow();
 	}
 
-	if ( mainWindow !== null ) mainWindow.show();
+	if (mainWindow) {
+		mainWindow.show();
+	}
 });
 
 app.on('before-quit', function () {


### PR DESCRIPTION
This PR fixes `Cannot read property 'show' of undefined` error on Mac when focusing on app before providing master password