### PR TITLE
Fix adding more than 25 services

### DIFF
--- a/app/store/Services.js
+++ b/app/store/Services.js
@@ -10,6 +10,7 @@ Ext.define('Rambox.store.Services', {
 
 	,autoLoad: true
 	,autoSync: true
+	,pageSize: 0
 
 	,groupField: 'align'
 	,sorters: [


### PR DESCRIPTION
If you add more than 25 services, after adding appears the new tab, but when you restart Rambox, the newer service (26th) is not in the services list and the tab is not opened.

When adding the 27th service, error is generated in the console and adding new services is not possible.

This is due to Sencha defaults to pageSize = 25 when not defined. (https://docs.sencha.com/extjs/6.2.0/modern/Ext.data.ProxyStore.html#cfg-pageSize)