### PR TITLE
Allow to send accept language header to websites, according to settings & edited getUserAgent regexp

### DIFF
--- a/app/ux/WebView.js
+++ b/app/ux/WebView.js
@@ -190,7 +190,7 @@ Ext.define('Rambox.ux.WebView',{
 	}
 	,getUserAgent: function() {
 		var ua = ipc.sendSync('getConfig').user_agent ? ipc.sendSync('getConfig').user_agent : Ext.getStore('ServicesList').getById(this.record.get('type')).get('userAgent')
-		return ua.length === 0 ? window.clientInformation.userAgent.replace(/Rambox\/([0-9]\.?)+\s/,'').replace(/Electron\/([0-9]\.?)+\s/,'') : ua;
+		return ua.length === 0 ? window.clientInformation.userAgent.replace(/Rambox\/([0-9]\.?)+\s/ig,'').replace(/Electron\/([0-9]\.?)+\s/ig,'') : ua;
 	}
 
 	,statusBarConstructor: function(floating) {

--- a/electron/main.js
+++ b/electron/main.js
@@ -58,7 +58,7 @@ if (config.get('enable_hidpi_support') && (process.platform === 'win32')) {
 	app.commandLine.appendSwitch('force-device-scale-factor', '1')
 }
 
-app.commandLine.appendSwitch('lang', config.get('locale') === 'en' ? 'en-US' :  config.get('locale'))
+app.commandLine.appendSwitch('lang', config.get('locale') === 'en' ? 'en-US' :  config.get('locale'));
 
 // Because we build it using Squirrel, it will assign UserModelId automatically, so we match it here to display notifications correctly.
 // https://github.com/electron-userland/electron-builder/issues/362

--- a/electron/main.js
+++ b/electron/main.js
@@ -58,6 +58,8 @@ if (config.get('enable_hidpi_support') && (process.platform === 'win32')) {
 	app.commandLine.appendSwitch('force-device-scale-factor', '1')
 }
 
+app.commandLine.appendSwitch('lang', config.get('locale') === 'en' ? 'en-US' :  config.get('locale'))
+
 // Because we build it using Squirrel, it will assign UserModelId automatically, so we match it here to display notifications correctly.
 // https://github.com/electron-userland/electron-builder/issues/362
 app.setAppUserModelId('com.grupovrs.ramboxce');


### PR DESCRIPTION
# Accept Language header
Now send the correct language, not based on the OS settings anymore, but on the Rambox settings.

![image](https://user-images.githubusercontent.com/12765875/56346455-65bdd480-61c2-11e9-8c20-8dab4f931405.png)
Language set in settings

![image](https://user-images.githubusercontent.com/12765875/56346232-f6e07b80-61c1-11e9-8258-56217fd4e179.png)
What it send to websites

![image](https://user-images.githubusercontent.com/12765875/56346493-7b32fe80-61c2-11e9-8571-14766128df77.png)
Example on google.com
# Edited getUserAgent regexp

Better expression matching

Closes #2169 
Should closes #2207