### PR TITLE
Fix Outlook 365 unread counter

### DIFF
--- a/app/store/ServicesList.js
+++ b/app/store/ServicesList.js
@@ -209,7 +209,7 @@ Ext.define('Rambox.store.ServicesList', {
 			,url: 'https://outlook.office.___/owa/'
 			,type: 'email'
 			,manual_notifications: true
-			,js_unread: 'function checkUnread(){var a=$(".subfolders [role=treeitem]:first .treeNodeRowElement").siblings().last().text();updateBadge(""===a?0:parseInt(a))}function updateBadge(a){a>=1?rambox.setUnreadCount(a):rambox.clearUnreadCount()}setInterval(checkUnread,3e3);'
+			,js_unread: 'function checkUnread(){var fav=$(".ms-FocusZone [role=tree]:first i[data-icon-name=Inbox]").siblings()[1];var folders=$(".ms-FocusZone [role=tree]:nth(1)")[0].children[1].querySelector("span span");var e=undefined!==fav?fav.innerText:null!==folders?folders.innerText:0;updateBadge(""===e?0:parseInt(e))}function updateBadge(e){1<=e?rambox.setUnreadCount(e):rambox.clearUnreadCount()}setInterval(checkUnread,3e3);'
 			,note: 'Please insert the cloud region you want to use. Can be "com", "de", etc.'
 		},
 		{


### PR DESCRIPTION
This fixes the unread counter for Outlook 365, which got broken in their latest redesign.
I've tried to make it as robust as possible, so I've tested it works in the following scenarios:
- You have either your 'Favorites' section or 'Folders' section expanded (or both)
- You've removed Inbox from your Favorites
- Your Inbox folder has subfolders, so we can't rely on the Inbox icon (it shows an 'expand more' arrow instead)

Closes #2114 
Closes #2373 

(Both of those issues got fixed for 'standard' Outlook in https://github.com/ramboxapp/community-edition/commit/d619a66a99eb5d311d37ce1e5291e173fb21ef5a, this completes the fix by fixing it for Outlook 365.)


