### PR TITLE
Update Slack icon fetching script

### DIFF
--- a/app/util/IconLoader.js
+++ b/app/util/IconLoader.js
@@ -19,7 +19,7 @@ Ext.define('Rambox.util.IconLoader', {
 			switch (service.type) {
 				case 'slack':
 					webview.executeJavaScript(
-						"(()=>{let a=document.querySelector('.team_icon');if(!a){const d=document.querySelector('#team_menu');d&&(d.click(),a=document.querySelector('.team_icon'))}if(!a)return!1;const{style:{backgroundImage:b}}=a,c=document.createEvent('MouseEvents');return c.initEvent('mousedown',!0,!0),document.querySelector('.client_channels_list_container').dispatchEvent(c),b.slice(5,-2)})();",
+						"(a=>window.slackDebug.activeTeam.redux.getState().teams[a].icon.image_44)(window.slackDebug.activeTeamId);",
 						false,
 						function (backgroundImage) {
 							if (backgroundImage) {

--- a/app/ux/WebView.js
+++ b/app/ux/WebView.js
@@ -300,9 +300,7 @@ Ext.define('Rambox.ux.WebView',{
 			webview.setZoomLevel(me.record.get('zoomLevel'));
 
 			// Set special icon for some service (like Slack)
-			setTimeout(function() {
-				Rambox.util.IconLoader.loadServiceIconUrl(me, webview);
-			}, 1000);
+			Rambox.util.IconLoader.loadServiceIconUrl(me, webview);
 		});
 
 		// On search text


### PR DESCRIPTION
Fixes #2355.

Using an alternative method to extract the icon from Slack. Debatable how hacky using `window.slackDebug` is versus poking around the DOM (which is how this piece broke in the first place). At least we can remove the `setTimeout` this way.