### PR TITLE
Add Option to define NTLM Domains for automatic authentication

### DIFF
--- a/app/view/preferences/Preferences.js
+++ b/app/view/preferences/Preferences.js
@@ -281,6 +281,15 @@ Ext.define('Rambox.view.preferences.Preferences',{
 						,emptyText: 'Leave blank for default user agent'
 					}
 					,{
+						xtype: 'textfield'
+						,fieldLabel: 'Allow NTLM Authentication for specified Domains (needs to relaunch)'
+						,labelAlign: 'top'
+						,name: 'ntlm_domains'
+						,value: config.ntlm_domains
+						,width: 360
+						,emptyText: 'Leave blank for no Domains'
+					}
+					,{
 						 xtype: 'fieldset'
 						,title: locale['preferences[24]']
 						,collapsed: !config.master_password

--- a/electron/main.js
+++ b/electron/main.js
@@ -41,6 +41,7 @@ const config = new Config({
 		,locale: 'en'
 		,enable_hidpi_support: false
 		,user_agent: ''
+		,ntlm_domains: ''
 		,default_service: 'ramboxTab'
 		,sendStatistics: false
 
@@ -105,6 +106,7 @@ function createWindow () {
 
 	// Check if user has defined a custom User-Agent
 	if ( config.get('user_agent').length > 0 ) mainWindow.webContents.setUserAgent( config.get('user_agent') );
+	if ( config.get('ntlm_domains').length > 0 ) session.defaultSession.allowNTLMCredentialsForDomains( config.get('ntlm_domains') );
 
 	if ( !config.get('start_minimized') && config.get('maximized') ) mainWindow.maximize();
 	if ( config.get('window_display_behavior') !== 'show_trayIcon' && config.get('start_minimized') ) {


### PR DESCRIPTION
This PR adds a new Option in Preferences to define allowed Domains for NTLM Authentication.
Useful for Authentication with SSO Provider