### PR TITLE
fix switching tabs with shortcuts

### DIFF
--- a/ext/src/tab/Panel.js
+++ b/ext/src/tab/Panel.js
@@ -43,12 +43,12 @@
  *             }
  *         }]
  *     });
- * 
+ *
  * ## Vetoing Changes
- * 
+ *
  * User interaction when changing the tabs can be vetoed by listening to the {@link #beforetabchange} event.
  * By returning `false`, the tab change will not occur.
- * 
+ *
  *     @example
  *     Ext.create('Ext.tab.Panel', {
  *         renderTo: Ext.getBody(),
@@ -66,7 +66,7 @@
  *         }, {
  *             title: 'P3'
  *         }]
- *     }); 
+ *     });
  *
  * # Examples
  *
@@ -316,8 +316,8 @@ Ext.define('Ext.tab.Panel', {
 
         /**
          * @cfg {"top"/"bottom"/"left"/"right"} tabPosition
-         * The position where the tab strip should be rendered. Possible values are: 
-         * 
+         * The position where the tab strip should be rendered. Possible values are:
+         *
          *  - top
          *  - bottom
          *  - left
@@ -488,13 +488,13 @@ Ext.define('Ext.tab.Panel', {
             tabBar.setActiveTab(activeTab.tab, true);
         }
     },
-    
+
     /**
      * @method getTabBar
      * Returns the {@link Ext.tab.Bar} associated with this tabPanel.
      * @return {Ext.tab.Bar} The tabBar for this tabPanel
      */
-    
+
     /**
      * @method setTabBar
      * @hide
@@ -573,6 +573,9 @@ Ext.define('Ext.tab.Panel', {
             else {
                 Ext.resumeLayouts(true);
             }
+						var currentTab = me.getActiveTab();
+						var content = currentTab.body.dom.querySelector('webview');
+						if (content) content.focus();
             return card;
         }
         return previous;
@@ -771,7 +774,7 @@ Ext.define('Ext.tab.Panel', {
     onItemIconChange: function(item, newIcon) {
         item.tab.setIcon(newIcon);
     },
-    
+
     /**
      * @private
      * Update the tab iconCls when panel iconCls has been set or changed.


### PR DESCRIPTION
I'm not sure if this is a correct way to do it, but I'm sure it works

# The issue
When I `<alt | ⌘>` `tab` into Rambox, it nicely focuses on the current service, same when I switch tabs by clicking on them, however, when trying to use `<ctrl | ⌘>` `<tab | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9>` the focus remains on the last service.

### Example:
I have following tabs: messenger, Telegram and WhatsApp. I am focused to message boxes on each one. I am on Telegram. I use ctrl+tab and try to type sth into WhatsApp, then press return/enter and see there's nothing being sent. When I come back to Telegram I can see that I've sent the message to the person I was talking with on Telegram.

# Solution
Try to focus on the webView of current service after each tab change