### PR TITLE
Fix/#2077 - stop rambox when running out of space, to prevent losing service tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,6 +209,7 @@
 		"auth0-js": "9.13.2",
 		"auto-launch-patched": "5.0.2",
 		"crypto": "1.0.1",
+		"diskusage": "1.1.3",
 		"electron-contextmenu-wrapper": "2.0.0",
 		"electron-is-dev": "0.3.0",
 		"electron-log": "2.2.17",


### PR DESCRIPTION
Fixes #2077 

I have 0 experience in Electron, and minimum in Node development, so pardon any funny funnies.

At app start, a watchdog for free disk space starts.
It checks every minute if available disk space < 1 GB. The check is asynchronous, so shouldn't affect normal usage.

Space check is used with new  module - diskspace - which works on Windows Linux and Mac.
I've tested the app only on Linux, but should work just fine anywhere. **It'd be best if someone tested on Windows and Mac.**

If the partition where Rambox is running from has < 1 GB available space:
* a warning dialog appears and Rambox freezes (synchronous dialog).
Dialog has info about:
* * remaining space
* * rambox/electron installation path
* * instruction to free up more space and that the app will exit upon dialog dismissal
* * OK button which quits Rambox

No matter how the dialog is dismissed, Rambox quits.

To test, you can manipulate the `if (available < 1073741824) { // 1 GB` line. 
F.e if you have 20 GB free, set: `if (available < 1073741824 * 21)` and run app - dialog should appear.

Preview (shows large free space, but that was for tests only, popup will show only if < 1 GB free:
![Screen Capture_electron_20200902213831](https://user-images.githubusercontent.com/7596867/92031006-30d70100-ed68-11ea-8e7c-23a5229c138f.png)
